### PR TITLE
Util.cpp: Fix compilation with GCC6

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -42,9 +42,9 @@ pkg_check_modules(GLIB2 REQUIRED glib-2.0)
 include_directories(${GLIB2_INCLUDE_DIRS})
 webos_add_compiler_flags(ALL ${GLIB2_CFLAGS})
 
-pkg_check_modules(CJSON cjson)
-include_directories(${CJSON_INCLUDE_DIRS})
-webos_add_compiler_flags(ALL ${CJSON_CFLAGS})
+pkg_check_modules(JSON json-c)
+include_directories(${JSON_INCLUDE_DIRS})
+webos_add_compiler_flags(ALL ${JSON_CFLAGS})
 
 #pkg_check_modules(MOJODB mojodb)
 #include_directories(${MOJODB_INCLUDE_DIRS})
@@ -106,7 +106,7 @@ aux_source_directory(src/util util_files)
 
 add_library(email-common SHARED src/CommonErrors.cpp ${activity_files} ${client_files} ${data_files} ${exceptions_files} ${mimeparser_files} ${stream_files} ${async_files} ${email_files} ${glibcurl_files} ${network_files} ${util_files})
 
-target_link_libraries(email-common ${GLIB2_LDFLAGS} ${CJSON_LDFLAGS} ${PALMSOCKET_LDFLAGS} ${SANDBOX_LDFLAGS} ${PMLOG_LDFLAGS} ${LUNASERVICE_LDFLAGS} ${JEMALLOC_MT_LDFLAGS} ${ICU} ${ICUI18N} ${LIBZ} ${Boost_LIBRARIES} ${DB8_LDFLAGS} pthread curl)
+target_link_libraries(email-common ${GLIB2_LDFLAGS} ${JSON_LDFLAGS} ${PALMSOCKET_LDFLAGS} ${SANDBOX_LDFLAGS} ${PMLOG_LDFLAGS} ${LUNASERVICE_LDFLAGS} ${JEMALLOC_MT_LDFLAGS} ${ICU} ${ICUI18N} ${LIBZ} ${Boost_LIBRARIES} ${DB8_LDFLAGS} pthread curl)
 
 webos_build_pkgconfig()
 webos_build_library(NAME email-common)

--- a/imap/CMakeLists.txt
+++ b/imap/CMakeLists.txt
@@ -50,9 +50,9 @@ pkg_check_modules(LUNASERVICE REQUIRED luna-service2)
 include_directories(${LUNASERVICE_INCLUDE_DIRS})
 webos_add_compiler_flags(ALL ${LUNASERVICE_CFLAGS})
 
-pkg_check_modules(CJSON cjson)
-include_directories(${CJSON_INCLUDE_DIRS})
-webos_add_compiler_flags(ALL ${CJSON_CFLAGS})
+pkg_check_modules(JSON json-c)
+include_directories(${JSON_INCLUDE_DIRS})
+webos_add_compiler_flags(ALL ${JSON_CFLAGS})
 
 pkg_check_modules(EMAILCOMMON email-common)
 include_directories(${EMAILCOMMON_INCLUDE_DIRS})

--- a/imap/src/commands/SelectFolderCommand.cpp
+++ b/imap/src/commands/SelectFolderCommand.cpp
@@ -183,7 +183,7 @@ void SelectFolderCommand::SelectDone()
 {
 	CommandTraceFunction();
 
-	boost::shared_ptr<FolderSession> folderSession = make_shared<FolderSession>(m_folder);
+	boost::shared_ptr<FolderSession> folderSession = boost::make_shared<FolderSession>(m_folder);
 
 	if(m_responseParser->GetExistsCount() > 0) // -1 means unknown
 		folderSession->SetMessageCount( m_responseParser->GetExistsCount() );

--- a/imap/src/commands/SyncEmailsCommand.cpp
+++ b/imap/src/commands/SyncEmailsCommand.cpp
@@ -201,7 +201,7 @@ void SyncEmailsCommand::SearchComplete()
 
 	unsigned int maxSize = ImapConfig::GetConfig().GetMaxEmails();
 
-	m_uidMap = make_shared<UIDMap>(m_allUIDs, folderSession->GetMessageCount(), maxSize);
+	m_uidMap = boost::make_shared<UIDMap>(m_allUIDs, folderSession->GetMessageCount(), maxSize);
 	folderSession->SetUIDMap(m_uidMap);
 
 	// Sort lists

--- a/imap/src/parser/SemanticActions.cpp
+++ b/imap/src/parser/SemanticActions.cpp
@@ -629,7 +629,7 @@ void SemanticActions::envMessageId() {
 }
 
 void SemanticActions::envEndAddress() {
-	EmailAddressPtr address = make_shared<EmailAddress>(m_envelope.m_addressDisplayName, m_envelope.m_addressEmail);
+	EmailAddressPtr address = boost::make_shared<EmailAddress>(m_envelope.m_addressDisplayName, m_envelope.m_addressEmail);
 	m_envelope.GetCurrentAddressList()->push_back(address);
 }
 

--- a/imap/src/parser/Util.cpp
+++ b/imap/src/parser/Util.cpp
@@ -45,7 +45,7 @@ static char STANDARD_ALPHABET[] =
     '6', '7', '8', '9', '+', ','
 };
 
-static char UTF7_DECODABET[] =
+static signed char UTF7_DECODABET[] =
     {
         -9,-9,-9,-9,-9,-9,-9,-9,-9,                 // Decimal  0 -  8
         -5,-5,                                      // Whitespace: Tab and Linefeed

--- a/pop/CMakeLists.txt
+++ b/pop/CMakeLists.txt
@@ -50,9 +50,9 @@ pkg_check_modules(LUNASERVICE REQUIRED luna-service2)
 include_directories(${LUNASERVICE_INCLUDE_DIRS})
 webos_add_compiler_flags(ALL ${LUNASERVICE_CFLAGS})
 
-pkg_check_modules(CJSON cjson)
-include_directories(${CJSON_INCLUDE_DIRS})
-webos_add_compiler_flags(ALL ${CJSON_CFLAGS})
+pkg_check_modules(JSON json-c)
+include_directories(${JSON_INCLUDE_DIRS})
+webos_add_compiler_flags(ALL ${JSON_CFLAGS})
 
 #pkg_check_modules(MOJODB mojodb)
 #include_directories(${MOJODB_INCLUDE_DIRS})

--- a/pop/src/PopBusDispatcher.cpp
+++ b/pop/src/PopBusDispatcher.cpp
@@ -668,7 +668,7 @@ PopBusDispatcher::ClientPtr PopBusDispatcher::GetOrCreateClient(MojObject& accou
 	it = m_clients.find(accountId);
 	if (it == m_clients.end()) {
 		MojLogInfo(s_log, "Creating PopClient");
-		shared_ptr<DatabaseInterface> databaseInterface(new MojoDatabase(m_dbClient));
+		boost::shared_ptr<DatabaseInterface> databaseInterface(new MojoDatabase(m_dbClient));
 		client.reset(new PopClient(databaseInterface, this, accountId, &m_service));
 		m_clients[accountId] = client;
 		client->CreateSession();

--- a/smtp/CMakeLists.txt
+++ b/smtp/CMakeLists.txt
@@ -50,9 +50,9 @@ pkg_check_modules(LUNASERVICE REQUIRED luna-service2)
 include_directories(${LUNASERVICE_INCLUDE_DIRS})
 webos_add_compiler_flags(ALL ${LUNASERVICE_CFLAGS})
 
-pkg_check_modules(CJSON cjson)
-include_directories(${CJSON_INCLUDE_DIRS})
-webos_add_compiler_flags(ALL ${CJSON_CFLAGS})
+pkg_check_modules(JSON json-c)
+include_directories(${JSON_INCLUDE_DIRS})
+webos_add_compiler_flags(ALL ${JSON_CFLAGS})
 
 #pkg_check_modules(MOJODB mojodb)
 #include_directories(${MOJODB_INCLUDE_DIRS})

--- a/smtp/src/SmtpClient.cpp
+++ b/smtp/src/SmtpClient.cpp
@@ -40,7 +40,7 @@ SmtpClient::ClientStatus::ClientStatus()
 
 }
 
-SmtpClient::SmtpClient(SmtpBusDispatcher* smtpBusDispatcher, shared_ptr<DatabaseInterface> dbInterface, shared_ptr<DatabaseInterface> tempDbInterface, MojLunaService* service)
+SmtpClient::SmtpClient(SmtpBusDispatcher* smtpBusDispatcher, boost::shared_ptr<DatabaseInterface> dbInterface, boost::shared_ptr<DatabaseInterface> tempDbInterface, MojLunaService* service)
 : BusClient(service),
   m_smtpBusDispatcher(smtpBusDispatcher),
   m_dbInterface(dbInterface),


### PR DESCRIPTION
To address issues like:

|
|

error: narrowing conversion of '-9' from 'int' to 'char' inside { }
[-Wnarrowing]

Signed-off-by: Herman van Hazendonk github.com@herrie.org
